### PR TITLE
fix: don't set prefix for li element outside list

### DIFF
--- a/testdata/TestCommonmark/list/goldmark.golden
+++ b/testdata/TestCommonmark/list/goldmark.golden
@@ -184,3 +184,4 @@ with two lines.</p>
 <p>before <em>middle</em> after</p>
 </li>
 </ul>
+<p>Not in a list</p>

--- a/testdata/TestCommonmark/list/input.html
+++ b/testdata/TestCommonmark/list/input.html
@@ -164,3 +164,6 @@ works
     <li>before<em>middle</em> after</li>
     <li>before <em>middle</em>after</li>
 </ul>
+
+<!--li not in a list-->
+<li>Not in a list</li>

--- a/testdata/TestCommonmark/list/output.asterisks.golden
+++ b/testdata/TestCommonmark/list/output.asterisks.golden
@@ -103,3 +103,5 @@
 * before _middle_ after
 * before _middle_ after
 * before _middle_ after
+
+Not in a list

--- a/testdata/TestCommonmark/list/output.dash.golden
+++ b/testdata/TestCommonmark/list/output.dash.golden
@@ -103,3 +103,5 @@
 - before _middle_ after
 - before _middle_ after
 - before _middle_ after
+
+Not in a list

--- a/testdata/TestCommonmark/list/output.plus.golden
+++ b/testdata/TestCommonmark/list/output.plus.golden
@@ -103,3 +103,5 @@
 + before _middle_ after
 + before _middle_ after
 + before _middle_ after
+
+Not in a list

--- a/utils.go
+++ b/utils.go
@@ -367,17 +367,19 @@ func getListPrefix(opt *Options, s *goquery.Selection) string {
 	parent := s.Parent()
 	if parent.Is("ul") {
 		return opt.BulletListMarker + " "
+	} else if parent.Is("ol") {
+		currentIndex := s.Index() + 1
+
+		lastIndex := parent.Children().Last().Index() + 1
+		maxLength := len(strconv.Itoa(lastIndex))
+
+		// pad the numbers so that all prefix numbers in the list take up the same space
+		// `%02d.` -> "01. "
+		format := `%0` + strconv.Itoa(maxLength) + `d. `
+		return fmt.Sprintf(format, currentIndex)
 	}
-
-	currentIndex := s.Index() + 1
-
-	lastIndex := parent.Children().Last().Index() + 1
-	maxLength := len(strconv.Itoa(lastIndex))
-
-	// pad the numbers so that all prefix numbers in the list take up the same space
-	// `%02d.` -> "01. "
-	format := `%0` + strconv.Itoa(maxLength) + `d. `
-	return fmt.Sprintf(format, currentIndex)
+	// If the HTML is malformed and the list element isn't in a ul or ol, return no prefix
+	return ""
 }
 
 // countListParents counts how much space is reserved for the prefixes at all the parent lists.


### PR DESCRIPTION
Our internal fuzzer found that this package would timeout when handling the following testcase: [testcase-timeout.txt](https://github.com/JohannesKaufmann/html-to-markdown/files/8143390/testcase-timeout.txt). It appears to be caused by the assumption that, if a `<li>` doesn't have a `<ul>` as a parent, the parent must be a `<ol>`. However, with malformed HTML this may not be the case. This issue is remedied by also checking if the parent is a `<ol>`, and if the parent is neither a `<ul>` nor a `<ol>` returning no list prefix.

