### PR TITLE
Add support for youtube-nocookie.com domain in YoutubeEmbed plugin

### DIFF
--- a/plugin/iframe_youtube.go
+++ b/plugin/iframe_youtube.go
@@ -9,7 +9,7 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
-var youtubeID = regexp.MustCompile(`youtube\.com\/embed\/([^\&\?\/]+)`)
+var youtubeID = regexp.MustCompile(`(?:youtube\.com|youtube-nocookie\.com)\/embed\/([^\&\?\/]+)`)
 
 // YoutubeEmbed registers a rule (for iframes) and
 // returns a markdown compatible representation (link to video, ...).
@@ -20,18 +20,19 @@ func YoutubeEmbed() md.Plugin {
 				Filter: []string{"iframe"},
 				Replacement: func(content string, selec *goquery.Selection, opt *md.Options) *string {
 					src := selec.AttrOr("src", "")
-					if !strings.Contains(src, "youtube.com") {
+					if !strings.Contains(src, "youtube.com") && !strings.Contains(src, "youtube-nocookie.com") {
+						fmt.Println("Not a YouTube iframe:", src)
 						return nil
 					}
 					alt := selec.AttrOr("title", "")
-
 					parts := youtubeID.FindStringSubmatch(src)
 					if len(parts) != 2 {
+						fmt.Println("YouTube ID not found in src:", src)
 						return nil
 					}
 					id := parts[1]
-
 					text := fmt.Sprintf("[![%s](https://img.youtube.com/vi/%s/0.jpg)](https://www.youtube.com/watch?v=%s)", alt, id, id)
+					fmt.Println("YouTube video embedded:", text)
 					return &text
 				},
 			},


### PR DESCRIPTION
### Description

This pull request adds support for handling YouTube iframes using the `youtube-nocookie.com` domain in the `YoutubeEmbed` plugin. 

### Changes Made

- Updated the regular expression in `iframe_youtube.go` to include `youtube-nocookie.com`.
- Added debug messages for easier verification.

### Justification

`youtube-nocookie.com` is a variant of YouTube that is used to enhance user privacy by not storing cookies. These changes will allow the plugin to correctly handle these iframes.

Thank you for considering this improvement.