### PR TITLE
plugin(table): Add option to preserve tables with new lines

### DIFF
--- a/plugin/table/2_collect.go
+++ b/plugin/table/2_collect.go
@@ -99,13 +99,15 @@ func (p *tablePlugin) collectTableContent(ctx converter.Context, node *html.Node
 		return nil
 	}
 
-	for _, cells := range rows {
-		for _, cell := range cells {
+	for i, cells := range rows {
+		for j, cell := range cells {
 			if containsNewline(cell) {
-				// Having newlines inside the content would break the table.
-				// So unfortunately we cannot convert the table.
-				//
-				// Note: We already trimmed the content earlier.
+				if p.newlineBehavior == NewlineBehaviorPreserve {
+					// Replace newlines with <br /> tags
+					rows[i][j] = bytes.ReplaceAll(cell, []byte("\n"), []byte("<br />"))
+					continue
+				}
+				// We're configured to skip tables with newlines, return nil
 				return nil
 			}
 		}

--- a/plugin/table/table.go
+++ b/plugin/table/table.go
@@ -40,6 +40,37 @@ func WithSpanCellBehavior(behavior SpanCellBehavior) option {
 	}
 }
 
+type NewlineBehavior string
+
+const (
+	// NewlineBehaviorSkip skips tables with newlines in cells (default).
+	NewlineBehaviorSkip NewlineBehavior = "skip"
+	// NewlineBehaviorPreserve preserves newlines in cells.
+	NewlineBehaviorPreserve NewlineBehavior = "preserve"
+)
+
+// WithNewlineBehavior configures how to handle newlines in table cells.
+// When set to NewlineBehaviorSkip (default), tables with newlines in cells are skipped.
+// When set to NewlineBehaviorPreserve, newlines are preserved in cells.
+//
+// Markdown tables don't support multiline content by default, so this provides a workaround to still convert tables with newlines.
+func WithNewlineBehavior(behavior NewlineBehavior) option {
+	return func(p *tablePlugin) error {
+		switch behavior {
+		case "":
+			// Allow empty string to default to Skip
+			return nil
+
+		case NewlineBehaviorSkip, NewlineBehaviorPreserve:
+			p.newlineBehavior = behavior
+			return nil
+
+		default:
+			return fmt.Errorf("unknown value %q for newline behavior", behavior)
+		}
+	}
+}
+
 // WithSkipEmptyRows configures the table plugin to omit empty rows from the output.
 // An empty row is defined as a row where all cells contain no content or only whitespace.
 // When set to true, empty rows will be omitted from the output. When false (default),
@@ -78,6 +109,7 @@ type tablePlugin struct {
 	err error
 
 	spanCellBehavior          SpanCellBehavior
+	newlineBehavior           NewlineBehavior
 	skipEmptyRows             bool
 	promoteFirstRowToHeader   bool
 	convertPresentationTables bool


### PR DESCRIPTION
I've added an option to preserve new lines in tables (as HTML `<br />` tags).
I'm aware that this is not standard, but it's nice to have the option to choose whether to apply this behavior or not, as the current behavior of completely skipping those tables is a bit too aggressive.