### PR TITLE
cli: add `tableNewlineBehavior` to options

### DIFF
--- a/cli/html2markdown/cmd/cmd_convert.go
+++ b/cli/html2markdown/cmd/cmd_convert.go
@@ -111,6 +111,7 @@ func (cli *CLI) convert(input []byte) ([]byte, error) {
 				table.WithHeaderPromotion(cli.config.tableHeaderPromotion),
 				table.WithSpanCellBehavior(table.SpanCellBehavior(cli.config.tableSpanCellBehavior)),
 				table.WithPresentationTables(cli.config.tablePresentationTables),
+				table.WithNewlineBehavior(table.NewlineBehavior(cli.config.tableNewlineBehavior)),
 			),
 		)
 	}

--- a/cli/html2markdown/cmd/exec.go
+++ b/cli/html2markdown/cmd/exec.go
@@ -45,6 +45,7 @@ type Config struct {
 	tableHeaderPromotion    bool
 	tableSpanCellBehavior   string
 	tablePresentationTables bool
+	tableNewlineBehavior    string
 }
 
 // Release holds the information (from the 3 ldflags) that goreleaser sets.

--- a/cli/html2markdown/cmd/flags.go
+++ b/cli/html2markdown/cmd/flags.go
@@ -93,6 +93,7 @@ func (cli *CLI) initFlags(progname string) {
 	cli.flags.BoolVar(&cli.config.tableHeaderPromotion, "opt-table-header-promotion", false, "[for --plugin-table] first row should be treated as a header")
 	cli.flags.StringVar(&cli.config.tableSpanCellBehavior, "opt-table-span-cell-behavior", "", `[for --plugin-table] how colspan/rowspan should be rendered: "empty" or "mirror"`)
 	cli.flags.BoolVar(&cli.config.tablePresentationTables, "opt-table-presentation-tables", false, `[for --plugin-table] whether tables with role="presentation" should be converted`)
+	cli.flags.StringVar(&cli.config.tableNewlineBehavior, "opt-table-newline-behavior", "", `[for --plugin-table] how tables containing newlines should be handled: "skip" or "preserve"`)
 }
 
 func (cli *CLI) parseFlags(args []string) error {
@@ -115,6 +116,9 @@ func (cli *CLI) parseFlags(args []string) error {
 	}
 	if cli.config.tablePresentationTables && !cli.config.enablePluginTable {
 		return fmt.Errorf("--opt-table-presentation-tables requires --plugin-table to be enabled")
+	}
+	if cli.config.tableNewlineBehavior != "" && !cli.config.enablePluginTable {
+		return fmt.Errorf("--opt-table-newline-behavior requires --plugin-table to be enabled")
 	}
 
 	// TODO: use constant for flag name & use formatFlag

--- a/cli/html2markdown/cmd/testdata/TestExecute/[general]_help_pipe/stdout.golden
+++ b/cli/html2markdown/cmd/testdata/TestExecute/[general]_help_pipe/stdout.golden
@@ -75,6 +75,9 @@ Use a HTML sanitizer before displaying the HTML in the browser!
     --opt-table-header-promotion
         [for --plugin-table] first row should be treated as a header
 
+    --opt-table-newline-behavior
+        [for --plugin-table] how tables containing newlines should be handled: "skip" or "preserve"
+
     --opt-table-presentation-tables
         [for --plugin-table] whether tables with role="presentation" should be converted
 

--- a/cli/html2markdown/cmd/testdata/TestExecute/[general]_help_terminal/stdout.golden
+++ b/cli/html2markdown/cmd/testdata/TestExecute/[general]_help_terminal/stdout.golden
@@ -75,6 +75,9 @@ Use a HTML sanitizer before displaying the HTML in the browser!
     --opt-table-header-promotion
         [for --plugin-table] first row should be treated as a header
 
+    --opt-table-newline-behavior
+        [for --plugin-table] how tables containing newlines should be handled: "skip" or "preserve"
+
     --opt-table-presentation-tables
         [for --plugin-table] whether tables with role="presentation" should be converted
 


### PR DESCRIPTION
Makes the `NewlineBehavior` option added in #156 available as an option via the CLI. It's usable as 
  `--opt-table-newline-behavior="[value]"`

Default value is still `skip`. 

I didn't change the tests since the CLI ones didn't seem to be updated with the addition of this option in the last PR. 