### PR TITLE
fix: prevent panic on empty Text Node

### DIFF
--- a/collapse/collapse.go
+++ b/collapse/collapse.go
@@ -101,8 +101,8 @@ func fillDefaultDomFuncs(domFuncs *DomFuncs) *DomFuncs {
 		domFuncs.IsPreformattedNode = defaultIsPreformattedNode
 	}
 	return domFuncs
-
 }
+
 func Collapse(element *html.Node, domFuncs *DomFuncs) {
 	domFuncs = fillDefaultDomFuncs(domFuncs)
 	// - - - - - - - - - - - - - - - - - - //
@@ -122,7 +122,7 @@ func Collapse(element *html.Node, domFuncs *DomFuncs) {
 			var text = replaceAnyWhitespaceWithSpace(node.Data)
 
 			if (prevText == nil || strings.HasSuffix(prevText.Data, " ")) &&
-				!keepLeadingWs && text!= "" && text[0] == ' ' {
+				!keepLeadingWs && text != "" && text[0] == ' ' {
 				text = text[1:]
 			}
 

--- a/collapse/collapse.go
+++ b/collapse/collapse.go
@@ -122,7 +122,7 @@ func Collapse(element *html.Node, domFuncs *DomFuncs) {
 			var text = replaceAnyWhitespaceWithSpace(node.Data)
 
 			if (prevText == nil || strings.HasSuffix(prevText.Data, " ")) &&
-				!keepLeadingWs && text[0] == ' ' {
+				!keepLeadingWs && text!= "" && text[0] == ' ' {
 				text = text[1:]
 			}
 

--- a/collapse/collapse_test.go
+++ b/collapse/collapse_test.go
@@ -108,6 +108,35 @@ span
 	`)
 }
 
+func TestCollapse_EmptyTextNode(t *testing.T) {
+	input := `<html><body>  <span>Hello </span> <span> World </span></body></html>`
+
+	doc, err := html.Parse(strings.NewReader(input))
+	if err != nil {
+		t.Error(err)
+	}
+
+	for d := range doc.Descendants() {
+		if d.Type == html.TextNode {
+			d.Data = ""
+			break
+		}
+	}
+
+	Collapse(doc, nil)
+
+	tester.ExpectRepresentation(t, doc, "after", `
+#document
+├─html
+│ ├─head
+│ ├─body
+│ │ ├─span
+│ │ │ ├─#text "Hello "
+│ │ ├─span
+│ │ │ ├─#text "World"
+	`)
+}
+
 func TestCollapse_Table(t *testing.T) {
 	runs := []struct {
 		desc  string


### PR DESCRIPTION
I am using go-trafilatura to extract Text from web pages.
The output is a html.Node tree and sometimes it lets some empty Text nodes.

This causes a panic in the collapse process when converting to markdown.

```
runtime error: index out of range [0] with length 0

	/Users/bmartinez/go/pkg/mod/github.com/!johannes!kaufmann/html-to-markdown/[v2@v2.5.0](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)/collapse/collapse.go:125 +0x628
github.com/JohannesKaufmann/html-to-markdown/v2/plugin/base.(*base).preRenderCollapse(0x1020fdb60, {0x101993228, 0x1400180a618}, 0x140034ec540)
	/Users/bmartinez/go/pkg/mod/github.com/!johannes!kaufmann/html-to-markdown/[v2@v2.5.0](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)/plugin/base/base.go:88 +0xb8
github.com/JohannesKaufmann/html-to-markdown/v2/converter.(*Converter).ConvertNode(0x140019bea80, 0x140034ec540, {0x14001b05af8, 0x1, 0x1})
	/Users/bmartinez/go/pkg/mod/github.com/!johannes!kaufmann/html-to-markdown/[v2@v2.5.0](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)/converter/convert.go:103
```