### PR TITLE
fix: populate version/commit from build info when not set by goreleaser

### DIFF
--- a/cli/html2markdown/main.go
+++ b/cli/html2markdown/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"runtime/debug"
 
 	"github.com/JohannesKaufmann/html-to-markdown/v2/cli/html2markdown/cmd"
 )
@@ -14,6 +15,23 @@ var (
 )
 
 func main() {
+	// Fall back to build info when not set by goreleaser
+	if version == "dev" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+			version = info.Main.Version
+		}
+	}
+	if commit == "none" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, s := range info.Settings {
+				if s.Key == "vcs.revision" && len(s.Value) >= 7 {
+					commit = s.Value[:7]
+					break
+				}
+			}
+		}
+	}
+
 	release := cmd.Release{
 		Version: version,
 		Commit:  commit,


### PR DESCRIPTION
Fixes #206

## Problem

When building from source with `go build ./cli/html2markdown`, the `-ldflags` are not set (only goreleaser sets them), so the CLI reports:

```
html2markdown dev (none) - unknown
```

## Fix

Use `runtime/debug.ReadBuildInfo()` as a fallback when:
- `version` is still `"dev"` → use `info.Main.Version` (set when installed via `go install`)
- `commit` is still `"none"` → use VCS revision from build settings

This means `go install github.com/JohannesKaufmann/html-to-markdown/v2/cli/html2markdown@v2.5.0` will show the correct version, and even a local `go build` will show the Git commit hash.